### PR TITLE
ADD timer t parameter to podtracer

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -10,7 +10,7 @@
       "request": "launch",
       "mode": "auto",
       "program": "${fileDirname}",
-      "args": ["run","ip", "-a", "addr", "--pod", "cnf-example-pod-98b9d4df8-m6wp8", "-n", "cnf-telco", "-o", "stdOut.txt"],
+      "args": ["run","tcpdump", "-a", "-i eth0", "--pod", "cnf-example-pod-98b9d4df8-m6wp8", "-n", "cnf-telco", "-t", "30s"],
       // "args": ["run"],
       "env": {"PODTRACER_LOGLEVEL":"INFO"}
     }


### PR DESCRIPTION
For binaries that run indefinitely such as tcpdump the parameter t sets
a timer duration for terminating the process.