### PR TITLE
REMOVE kubeconfig from flags

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ NAMESPACE ?= podtracer
 # in order to develop podtracer
 DEV_NAMESPACE ?= podtracer-dev
 BUILDER ?= podman
-IMG ?= quay.io/fennec-project/podtracer:0.0.1-12
+IMG ?= quay.io/fennec-project/podtracer:0.0.1-13
 
 # podtracer-build builds podtracer binary
 podtracer-build:

--- a/cmd/internal/podtracer/container.go
+++ b/cmd/internal/podtracer/container.go
@@ -39,10 +39,10 @@ type ContainerContext struct {
 	// task string
 }
 
-func (cctx *ContainerContext) Init(podName string, Namespace string, kubeconfigPath string) error {
+func (cctx *ContainerContext) Init(podName string, Namespace string) error {
 
 	// Create client
-	err := cctx.getClient(kubeconfigPath)
+	err := cctx.getClient()
 	if err != nil {
 		return err
 	}
@@ -79,7 +79,7 @@ func (cctx *ContainerContext) GetContainerPID() string {
 
 }
 
-func (cctx *ContainerContext) getClient(kubeconfigPath string) error {
+func (cctx *ContainerContext) getClient() error {
 
 	// TODO: link kubeconfigPath on client.new if empty default to ~/.kube/kubeconfig
 	client, err := client.New(config.GetConfigOrDie(), client.Options{})

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -105,7 +105,6 @@ func init() {
 	runCmd.Flags().StringVarP(&flags.targetArgs, "arguments", "a", "", "arguments to running cli utility.")
 	runCmd.Flags().StringVar(&flags.targetPodName, "pod", "", "Target pod name.")
 	runCmd.Flags().StringVarP(&flags.targetNamespace, "namespace", "n", "", "Kubernetes namespace where the target pod is running")
-	runCmd.Flags().StringVarP(&flags.kubeconfigPath, "kubeconfig", "k", "", "kubeconfig file path to connect to kubernetes cluster - defaults to $HOME/.kube/kubeconfig")
 	runCmd.Flags().StringVarP(&flags.stdoutFile, "stdoutFile", "o", "", "file path to save output data from the running tool.")
 	runCmd.Flags().StringVarP(&flags.destinationIP, "destination", "d", "", "Destination IP to where send stdout")
 	runCmd.Flags().StringVarP(&flags.destinationPort, "port", "p", "", "Destination port to where send stdout")
@@ -187,7 +186,7 @@ func cmdExec(cliTool string, w io.WriteCloser) {
 	// Initializing podtracer will get all pod and container
 	// information from kubeapi-server and container engine.
 	containerContext := Podtracer.ContainerContext{}
-	err := containerContext.Init(flags.targetPodName, flags.targetNamespace, flags.kubeconfigPath)
+	err := containerContext.Init(flags.targetPodName, flags.targetNamespace)
 	if err != nil {
 		log.Fatal(err)
 	}


### PR DESCRIPTION
Kubeconfig was used in the beginning for tests. Podtracer
now uses the token assigned to the service account that runs it.

That said no logic was added to kubeconfig. Instead kubeconfig
was removed as an option for now. There may be a use case to
inject a kubeconfig flag which would be a remote usage, i. e.,
podtracer being executed in a remote laptop against a cluster
on the cloud but that a full feature story which is not the
case for now.

To avoid confusion at this stage I'm removing kubeconfig from the 
flags. This can come back to our backlog in the future if the team
thinks it's valuable.

closes #6 
